### PR TITLE
[Don't merge] simulated issue : allow issues and : does it work yet ?

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "Feross Aboukhadijeh",
     "email": "feross@feross.org",
-    "url": "http://feross.org/"
+    "url": "http://feross.org/" 
   },
   "bin": {
     "webtorrent-hybrid": "./bin/cmd.js"


### PR DESCRIPTION
This repo is a fork so it's not possible to open issues by default. Could you allow issues in the settings ?

Also, I just tried seeding with webtorrent-hybrid-electron and getting that:

```
Downloading: Optimized-lion.jpg
Info hash: afab6da4de66fe729b8db422166b3f07284b7833
Speed: 0 B/s  Downloaded: 13.41 kB/13.41 kB  Uploaded: 0 B
Running time: 28s  Time remaining: a few seconds  Peers: 0/0


dc<< 1 open { state: 
   { maxRetransmits: 65535,
     negotiated: false,
     ordered: true,
     protocol: '',
     reliable: true },
  type: 'open' } true
dc<< 1 message { dataType: 'binary',
  event: 
   { data: 'E0JpdFRvcnJlbnQgcHJvdG9jb2wAAAAAABAAAK+rbaTeZv5ym420IhZrPwcoS3gzLVdXMDA3My05ZDE0NzgzYzI5ZDk=',
     origin: '' },
  type: 'message' } true
dc<< 1 open { state: 
Downloading: Optimized-lion.jpg
Info hash: afab6da4de66fe729b8db422166b3f07284b7833
Speed: 0 B/s  Downloaded: 13.41 kB/13.41 kB  Uploaded: 0 B
Running time: 50s  Time remaining: a few seconds  Peers: 0/1

0%  129.175.157.131:33819     0 B        0 B/s        0 B/s       

dc<< 65535 close { type: 'close' } false
dc<< 65535 close { type: 'close' } false
dc<< 65535 close { type: 'close' } false
dc<< 65535 close { type: 'close' } false
dc<< 65535 close { type: 'close' } false
dc<< 65535 close { type: 'close' } false
dc<< 65535 close { type: 'close' } false
dc<< 65535 close { type: 'close' } false
dc<< 65535 close { type: 'close' } false
dc<< 65535 close { type: 'close' } false
dc<< 65535 close { type: 'close' } false
dc<< 65535 close { type: 'close' } false
dc<< 65535 close { type: 'close' } false
dc<< 65535 close { type: 'close' } false
dc<< 65535 close { type: 'close' } false
dc<< 65535 close { type: 'close' } false
dc<< 65535 close { type: 'close' } false
dc<< 65535 close { type: 'close' } false
dc<< 65535 close { type: 'close' } false
dc<< 65535 close { type: 'close' } false
dc<< 65535 close { type: 'close' } false
dc<< 65535 close { type: 'close' } false
dc<< 65535 close { type: 'close' } false
dc<< 65535 close { type: 'close' } false
dc<< 65535 close { type: 'close' } false
dc<< 65535 close { type: 'close' } false
dc<< 65535 close { type: 'close' } false
dc<< 65535 close { type: 'close' } false
dc<< 65535 close { type: 'close' } false
dc<< 65535 close { type: 'close' } false
dc<< 65535 close { type: 'close' } false
dc<< 65535 close { type: 'close' } false
dc<< 65535 close { type: 'close' } false
Downloading: Optimized-lion.jpg
Downloading: Optimized-lion.jpg
Info hash: afab6da4de66fe729b8db422166b3f07284b7833
Speed: 0 B/s  Downloaded: 13.41 kB/13.41 kB  Uploaded: 0 B
Running time: 88s  Time remaining: a few seconds  Peers: 0/0


^C
webtorrent is exiting...
```

(that's when I tried downloading from instant.io)

Is this supposed to work yet ?
